### PR TITLE
feat: switch from `nodejs12.x` to `nodejs14.x`

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The permissions can also be added to all lambdas using setting the role to `IamR
 ```yaml
 provider:
   name: aws
-  runtime: nodejs10.x
+  runtime: nodejs14.x
   iamRoleStatements:
     - Effect: 'Allow'
       Action:

--- a/src/warmer.js
+++ b/src/warmer.js
@@ -218,7 +218,7 @@ function addWarmUpFunctionToService(service, warmerName, warmerConfig) {
     handler: warmerConfig.pathHandler,
     memorySize: warmerConfig.memorySize,
     name: warmerConfig.name,
-    runtime: 'nodejs12.x',
+    runtime: 'nodejs14.x',
     package: warmerConfig.package,
     timeout: warmerConfig.timeout,
     ...(Object.keys(warmerConfig.environment).length

--- a/test/utils/configUtils.js
+++ b/test/utils/configUtils.js
@@ -66,7 +66,7 @@ function getExpectedFunctionConfig(options = {}) {
     handler: path.join('.warmup', warmerName, 'index.warmUp'),
     memorySize: 128,
     name: `warmup-test-dev-warmup-plugin-${warmerName}`,
-    runtime: 'nodejs12.x',
+    runtime: 'nodejs14.x',
     package: {
       individually: true,
       exclude: ['**'],


### PR DESCRIPTION
`nodejs14.x` is also now supported.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html