### PR TITLE
Adjust schema to the strict mode

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -139,6 +139,7 @@ function extendServerlessSchema(serverless) {
     serverless.configSchemaHandler.defineCustomProperties({
       properties: {
         warmup: {
+          type: 'object',
           patternProperties: {
             '.*': {
               type: 'object',
@@ -156,6 +157,7 @@ function extendServerlessSchema(serverless) {
       type: 'object',
       properties: {
         warmup: {
+          type: 'object',
           patternProperties: {
             '.*': {
               type: 'object',


### PR DESCRIPTION
Adjust schema to the strict mode that is enabled by default since AJV v7.