### PR TITLE
Add missing null check when loading custom warmups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "eslint": "^8.5.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.24.2",
-        "husky": "^7.0.2",
+        "husky": "^8",
         "jest": "^27.5.0"
       }
     },
@@ -2741,15 +2741,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -7427,9 +7427,9 @@
       "dev": true
     },
     "husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Keep your lambdas warm during winter.",
   "main": "src/index.js",
   "scripts": {
+    "prepare": "husky install",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "test": "jest test",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Keep your lambdas warm during winter.",
   "main": "src/index.js",
   "scripts": {
-    "prepare": "husky install",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "test": "jest test",
@@ -34,6 +33,7 @@
     "eslint": "^8.5.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.24.2",
+    "husky": "^7.0.2",
     "jest": "^27.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^8.5.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.24.2",
-    "husky": "^7.0.2",
+    "husky": "^8",
     "jest": "^27.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^8.5.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.24.2",
-    "husky": "^8",
+    "husky": "^7.0.2",
     "jest": "^27.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eslint": "^8.5.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.24.2",
-    "husky": "^7.0.2",
     "jest": "^27.5.0"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -163,7 +163,9 @@ function getConfigsByWarmer({ service, classes }, stage) {
     concurrency: 1,
   };
 
-  const configsByWarmer = Object.entries(service.custom ? service.custom.warmup : {})
+  const customWarmup = service.custom != null ? service.custom.warmup : {};
+  console.log(JSON.stringify(customWarmup, null, 2));
+  const configsByWarmer = Object.entries(customWarmup)
     .reduce((warmers, [warmerName, warmerConfig]) => ({
       ...warmers,
       [warmerName]: {

--- a/src/config.js
+++ b/src/config.js
@@ -163,8 +163,9 @@ function getConfigsByWarmer({ service, classes }, stage) {
     concurrency: 1,
   };
 
-  const customWarmup = service.custom != null ? service.custom.warmup : {};
-  console.log(JSON.stringify(customWarmup, null, 2));
+  const customWarmup = (service.custom != null && service.custom.warmup != null)
+    ? service.custom.warmup
+    : {};
   const configsByWarmer = Object.entries(customWarmup)
     .reduce((warmers, [warmerName, warmerConfig]) => ({
       ...warmers,


### PR DESCRIPTION
This adds some extra null checking when loading custom warmups. Without it, `serverless deploy` would cause a crash when using the serverless typescript plugin (serverless.ts).