### PR TITLE
config.js Extra null check

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -163,7 +163,11 @@ function getConfigsByWarmer({ service, classes }, stage) {
     concurrency: 1,
   };
 
-  const configsByWarmer = Object.entries(service.custom ? service.custom.warmup : {})
+  const customWarmup = (service.custom != null && service.custom.warmup != null)
+    ? service.custom.warmup
+    : {};
+
+  const configsByWarmer = Object.entries(customWarmup)
     .reduce((warmers, [warmerName, warmerConfig]) => ({
       ...warmers,
       [warmerName]: {


### PR DESCRIPTION
This adds some extra null checking when loading custom warmups. Without it, `serverless deploy` would cause a crash when using the serverless typescript plugin (serverless.ts).