### PR TITLE
feat: include generated files for serverless dashboard in package pattern

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { capitalize } = require('./utils');
 
 /**
  * @description Clean a global configuration object
@@ -147,7 +148,7 @@ function getConfigsByWarmer({ service, classes }, stage) {
     events: [{ schedule: 'rate(5 minutes)' }],
     package: {
       individually: true,
-      patterns: [],
+      patterns: service.org ? ['./serverless_sdk/**', `./s_warmUpPlugin${capitalize(warmerName)}.js`] : [],
     },
     timeout: 10,
     environment: Object.keys(service.provider.environment || [])


### PR DESCRIPTION
When enabling **serverless dashboard** in the yml file by specifying `org` and `app`, by default serverless will wrap our lambda functions and add `serverless_sdk` to our lambda function, which then results for example:

<img width="165" alt="image" src="https://user-images.githubusercontent.com/11919795/172639454-cf805f54-177c-4235-b0d8-1d090bf30b50.png">

_Note: s_main.js comes from `s_$fn_name.js`_

But, since serverless-plugin-warmup by default only includes `warmup/${warmerName}/**` in the package pattern, the files generated for **serverless dashboard** will not be included when packaging the lambda (which then results error due to missing files).

<img width="190" alt="image" src="https://user-images.githubusercontent.com/11919795/172642971-dd827e8f-3504-4267-9b48-3ea771548658.png">

As we can see in the generated cloudformation file, the handler path is modified to the wrapped one:

<img width="351" alt="image" src="https://user-images.githubusercontent.com/11919795/172643743-0a5f91e1-8409-4711-b42a-3bdf42d96785.png">


Current workaround for this, is by specifying the generated files in package pattern:
```yml
warmup:
  enabled: true
  prewarm: true
  package:
    patterns:
      - './serverless_sdk/**'
      - './s_warmUpPluginDefault.js'
```

But I think would be better if those files are included by default, and this little PR will do that.

Would like to hear any feedback! Thank you
