### PR TITLE
chore: allow both qualified and unqualified ARNs

### DIFF
--- a/src/warmer.js
+++ b/src/warmer.js
@@ -94,7 +94,16 @@ function addWarmUpFunctionRoleToResources(service, stage, warmerName, warmerConf
                   'lambda:InvokeFunction',
                 ],
                 Resource: warmerConfig.functions.map((fn) => ({
-                  'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${fn.name}*`,
+                  'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${fn.name}`,
+                })),
+              },
+              {
+                Effect: 'Allow',
+                Action: [
+                  'lambda:InvokeFunction',
+                ],
+                Resource: warmerConfig.functions.map((fn) => ({
+                  'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${fn.name}:*`,
                 })),
               },
               {


### PR DESCRIPTION
Context: AFAICT  the previous pattern`arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${fn.name}*` would match both `my_function` and (probably not the intention of 142bdf016f9a286991e0866607d52b72e8f85d4a) `my_function-foo` but **not** `my_function:my-alias`