### PR TITLE
feat: optionally set warmer roleName if using default role

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The options are the same for all the warmers:
 * **folderName** Folder to temporarily store the generated code (defaults to `.warmup`)
 * **cleanFolder** Whether to automatically delete the generated code folder. You might want to keep it if you are doing some custom packaging (defaults to `true`)
 * **name** Name of the generated warmer lambda (defaults to `${service}-${stage}-warmup-plugin-${warmerName}`)
-* **roleName** RoleName to apply to the warmer lambda Role (defaults to the roleName in the provider)
+* **roleName** Name to be applied to the default warmer lambda role. Ignored if a the role setting is used (defaults to `${service.service}-${stage}-${region}-${warmerName.toLowerCase()}-role`)
 * **role** Role to apply to the warmer lambda (defaults to the role in the provider)
 * **tags** Tag to apply to the generated warmer lambda (defaults to the serverless default tags)
 * **vpc** The VPC and subnets in which to deploy. Can be any [Serverless VPC configuration](https://serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration) or be set to `false` in order to deploy the warmup function outside of a VPC (defaults to the vpc in the provider)
@@ -96,7 +96,7 @@ custom:
       cleanFolder: false
       memorySize: 256
       name: warmer-default
-      roleName:
+      roleName: my-custom-role
       role: WarmupRole
       tags:
         Project: foo

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The options are the same for all the warmers:
 * **folderName** Folder to temporarily store the generated code (defaults to `.warmup`)
 * **cleanFolder** Whether to automatically delete the generated code folder. You might want to keep it if you are doing some custom packaging (defaults to `true`)
 * **name** Name of the generated warmer lambda (defaults to `${service}-${stage}-warmup-plugin-${warmerName}`)
+* **roleName** RoleName to apply to the warmer lambda Role (defaults to the roleName in the provider)
 * **role** Role to apply to the warmer lambda (defaults to the role in the provider)
 * **tags** Tag to apply to the generated warmer lambda (defaults to the serverless default tags)
 * **vpc** The VPC and subnets in which to deploy. Can be any [Serverless VPC configuration](https://serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration) or be set to `false` in order to deploy the warmup function outside of a VPC (defaults to the vpc in the provider)
@@ -95,6 +96,7 @@ custom:
       cleanFolder: false
       memorySize: 256
       name: warmer-default
+      roleName:
       role: WarmupRole
       tags:
         Project: foo

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ function getWarmerConfig(config, defaultOpts) {
     pathHandler: path.join(folderName, 'index.warmUp'),
     cleanFolder: (typeof config.cleanFolder === 'boolean') ? config.cleanFolder : defaultOpts.cleanFolder,
     name: (config.name !== undefined) ? config.name : defaultOpts.name,
+    roleName: (config.roleName !== undefined) ? config.roleName : defaultOpts.roleName,
     role: (config.role !== undefined) ? config.role : defaultOpts.role,
     tags: (config.tags !== undefined) ? config.tags : defaultOpts.tags,
     vpc: config.vpc === false ? { securityGroupIds: [], subnetIds: [] }

--- a/src/schema.js
+++ b/src/schema.js
@@ -15,6 +15,7 @@ function extendServerlessSchema(serverless) {
     folderName: { type: 'string' },
     cleanFolder: { type: 'boolean' },
     name: { type: 'string' },
+    roleName: { type: 'string' },
     role: { $ref: '#/definitions/awsLambdaRole' },
     tags: { $ref: '#/definitions/awsResourceTags' },
     vpc: {

--- a/src/warmer.js
+++ b/src/warmer.js
@@ -26,17 +26,16 @@ function addWarmUpFunctionRoleToResources(service, stage, warmerName, warmerConf
     Type: 'AWS::IAM::Role',
     Properties: {
       Path: '/',
-      RoleName: warmerConfig.roleName ? warmerConfig.roleName : {
+      RoleName: warmerConfig.roleName || {
         'Fn::Join': [
           '-',
-          warmerConfig.roleName ? [warmerConfig.roleName]
-            : [
-              service.service,
-              stage,
-              { Ref: 'AWS::Region' },
-              warmerName.toLowerCase(),
-              'role',
-            ],
+          [
+            service.service,
+            stage,
+            { Ref: 'AWS::Region' },
+            warmerName.toLowerCase(),
+            'role',
+          ],
         ],
       },
       AssumeRolePolicyDocument: {

--- a/src/warmer.js
+++ b/src/warmer.js
@@ -26,16 +26,17 @@ function addWarmUpFunctionRoleToResources(service, stage, warmerName, warmerConf
     Type: 'AWS::IAM::Role',
     Properties: {
       Path: '/',
-      RoleName: {
+      RoleName: warmerConfig.roleName ? warmerConfig.roleName : {
         'Fn::Join': [
           '-',
-          [
-            service.service,
-            stage,
-            { Ref: 'AWS::Region' },
-            warmerName.toLowerCase(),
-            'role',
-          ],
+          warmerConfig.roleName ? [warmerConfig.roleName]
+            : [
+              service.service,
+              stage,
+              { Ref: 'AWS::Region' },
+              warmerName.toLowerCase(),
+              'role',
+            ],
         ],
       },
       AssumeRolePolicyDocument: {
@@ -233,6 +234,7 @@ function addWarmUpFunctionToService(service, warmerName, warmerConfig) {
     ...(warmerConfig.logRetentionInDays !== undefined
       ? { logRetentionInDays: warmerConfig.logRetentionInDays }
       : {}),
+    ...(warmerConfig.roleName ? { roleName: warmerConfig.roleName } : {}),
     ...(warmerConfig.role ? { role: warmerConfig.role } : {}),
     ...(warmerConfig.tags ? { tags: warmerConfig.tags } : {}),
     ...(warmerConfig.vpc ? { vpc: warmerConfig.vpc } : {}),

--- a/test/hook.warmupAddWamersAddWamers.test.js
+++ b/test/hook.warmupAddWamersAddWamers.test.js
@@ -1149,6 +1149,32 @@ describe('Serverless warmup plugin warmup:warmers:addWarmers:addWarmers hook', (
       }));
   });
 
+  it('Should use the roleName from options if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            default: {
+              enabled: true,
+              roleName: 'test-roleName',
+            },
+          },
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } },
+      },
+    });
+    const pluginUtils = getPluginUtils();
+    const plugin = new WarmUp(serverless, {}, pluginUtils);
+
+    await plugin.hooks['before:warmup:addWarmers:addWarmers']();
+    await plugin.hooks['warmup:addWarmers:addWarmers']();
+
+    expect(plugin.serverless.service.functions.warmUpPluginDefault)
+      .toEqual(getExpectedFunctionConfig({
+        roleName: 'test-roleName',
+      }));
+  });
+
   it('Should use the service roles from options if present', async () => {
     const serverless = getServerlessConfig({
       service: {
@@ -1309,7 +1335,7 @@ describe('Serverless warmup plugin warmup:warmers:addWarmers:addWarmers hook', (
       .toEqual(getExpectedFunctionConfig({ architecture: 'x86_64' }));
   });
 
-  it('Should overide provider architecture setting if set up at the warmer config', async () => {
+  it('Should override provider architecture setting if set up at the warmer config', async () => {
     const serverless = getServerlessConfig({
       service: {
         provider: {


### PR DESCRIPTION
Optionally set a roleName for the warmers.

## **Use Case:** 
Sometimes the default generated Role name exceeds the IAM max name length of 64 characters.

This causes deployments to fail for some users if they do not disable the warmers for deployments. 

### **Example:**
```
Error:
CREATE_FAILED: WarmUpPluginDefaultRole (AWS::IAM::Role)
1 validation error detected: Value 'apple-map-api-sandbox-ap-south-1-stack-sandbox-ap-south-1-default-role' at 'roleName' failed to satisfy constraint: Member must have length less than or equal to 64 (Service: AmazonIdentityManagement; Status Code: 400; Error Code: ValidationError; Request ID: 60b62c0f-18d8-4b63-80fe-672b1b5d8add; Proxy: null)
```
## **Cause:**
https://github.com/juanjoDiaz/serverless-plugin-warmup/blob/847b45cc675e8f12ea439b68283417feab562ef9/src/warmer.js#L25-L40


## **Fix:** 

Optionally provide warmer RoleName field for two main reasons:
1. Allow users to follow a specific naming structure across their accounts
2. Provide a workaround for the max character limit for IAM Role names. 


-----

`Please let me know if I have missed anything... Thanks!`


