### PR TITLE
fix: use own logger when one is not provided

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const {
   createWarmUpFunctionArtifact,
   addWarmUpFunctionToService,
 } = require('./warmer');
-const { capitalize } = require('./utils');
+const { capitalize, getLog } = require('./utils');
 
 /**
  * @classdesc Keep your lambdas warm during winter
@@ -34,7 +34,7 @@ class WarmUp {
     /** Serverless variables */
     this.serverless = serverless;
     this.cliOptions = cliOptions;
-    this.log = log;
+    this.log = log || getLog();
 
     this.provider = this.serverless.getProvider('aws');
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,13 @@
 const capitalize = (name) => name.charAt(0).toUpperCase() + name.slice(1);
 
+const getLog = () => ({
+  info: (message) => console.info(message),
+  notice: (message) => console.log(message),
+  warning: (message) => console.warn(message),
+  error: (message) => console.error(message),
+});
+
 module.exports = {
   capitalize,
+  getLog,
 };


### PR DESCRIPTION
Starting in serverless v3, plugins added using `pluginManager.addPlugin` do not receive a `log` instance. For more details see: https://github.com/serverless/serverless/issues/11412