### PR TITLE
migrate to AWS SDK v3

### DIFF
--- a/src/warmer.js
+++ b/src/warmer.js
@@ -133,7 +133,7 @@ async function createWarmUpFunctionArtifact(functions, tracing, verbose, region,
 ${tracing
     ? `const AWSXRay = require('aws-xray-sdk-core');
 const AWS = AWSXRay.captureAWS(require('@aws-sdk/client-lambda'));`
-    : 'const AWS = require("@aws-sdk/client-lambda")'};
+    : 'const AWS = require(\'@aws-sdk/client-lambda\')'};
 const lambda = new AWS.Lambda({
   apiVersion: '2015-03-31',
   region: '${region}'

--- a/src/warmer.js
+++ b/src/warmer.js
@@ -132,14 +132,11 @@ async function createWarmUpFunctionArtifact(functions, tracing, verbose, region,
 
 ${tracing
     ? `const AWSXRay = require('aws-xray-sdk-core');
-const AWS = AWSXRay.captureAWS(require('aws-sdk'));`
-    : 'const AWS = require(\'aws-sdk\')'};
+const AWS = AWSXRay.captureAWS(require('@aws-sdk/client-lambda'));`
+    : 'const AWS = require("@aws-sdk/client-lambda")'};
 const lambda = new AWS.Lambda({
   apiVersion: '2015-03-31',
-  region: '${region}',
-  httpOptions: {
-    connectTimeout: 1000, // 1 second
-  },
+  region: '${region}'
 });
 const functions = ${JSON.stringify(functions, null, '  ')};
 
@@ -189,7 +186,7 @@ module.exports.warmUp = async (event, context) => {
     };
 
     try {
-      await Promise.all(Array(concurrency).fill(0).map(async () => await lambda.invoke(params).promise()));
+      await Promise.all(Array(concurrency).fill(0).map(async () => await lambda.invoke(params)));
       logVerbose(\`Warm Up Invoke Success: \${func.name}\`);
       return true;
     } catch (e) {

--- a/test/utils/configUtils.js
+++ b/test/utils/configUtils.js
@@ -65,9 +65,6 @@ function getExpectedLambdaClientConfig(options = {}) {
   return {
     apiVersion: '2015-03-31',
     region: 'us-east-1',
-    httpOptions: {
-      connectTimeout: 1000,
-    },
     ...options,
   };
 }

--- a/test/utils/generatedFunctionTester.js
+++ b/test/utils/generatedFunctionTester.js
@@ -33,7 +33,7 @@ class GeneratedFunctionTester {
 
   executeWarmupFunction(args = {}) {
     this.generatedWarmupFunction()(
-      { 'aws-sdk': this.aws },
+      { '@aws-sdk/client-lambda': this.aws },
       args.process || { env: {} },
       args.console || { log: () => {}, error: () => {} },
     );


### PR DESCRIPTION
Hi @juanjoDiaz,

My previous PR for upgrading to NodeJS 18 actually broke this library, because there's a major change on NodeJS 18 which is to update AWS SDK from v2 to v3, so I created this PR for upgrading AWS SDK to v3.

Please review and release my code or build your own version if you don't like my code :)

https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/

Thanks,
CJ