### PR TITLE
fix: handle missing warmup configuration

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -167,7 +167,7 @@ function getConfigsByWarmer({ service, classes }, stage) {
     concurrency: 1,
   };
 
-  const configsByWarmer = Object.entries(service.custom ? service.custom.warmup : {})
+  const configsByWarmer = Object.entries((service.custom && service.custom.warmup) || {})
     .reduce((warmers, [warmerName, warmerConfig]) => ({
       ...warmers,
       [warmerName]: {

--- a/test/hook.warmupAddWamersAddWamers.test.js
+++ b/test/hook.warmupAddWamersAddWamers.test.js
@@ -2147,6 +2147,20 @@ describe('Serverless warmup plugin warmup:warmers:addWarmers:addWarmers hook', (
     }
   });
 
+  it('Should not error if the warmup configuration is missing', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {},
+        functions: {},
+      },
+    });
+    const pluginUtils = getPluginUtils();
+    const plugin = new WarmUp(serverless, {}, pluginUtils);
+
+    await plugin.hooks['before:warmup:addWarmers:addWarmers']();
+    await plugin.hooks['warmup:addWarmers:addWarmers']();
+  });
+
   describe('Packaging', () => {
     it('Should package only the lambda handler by default', async () => {
       const serverless = getServerlessConfig({


### PR DESCRIPTION
I ran into the following error in one of my projects:

```
TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at getConfigsByWarmer (project/node_modules/serverless-plugin-warmup/src/config.js:170:34)
    at WarmUp.configPlugin (project/node_modules/serverless-plugin-warmup/src/index.js:89:10)
    at PluginManager.runHooks (project/node_modules/serverless/lib/classes/plugin-manager.js:530:15)
    at PluginManager.invoke (project/node_modules/serverless/lib/classes/plugin-manager.js:563:20)
    at PluginManager.spawn (project/node_modules/serverless/lib/classes/plugin-manager.js:585:16)
    at after:package:initialize (project/node_modules/serverless-plugin-warmup/src/index.js:64:71)
    at PluginManager.runHooks (project/node_modules/serverless/lib/classes/plugin-manager.js:530:15)
    at PluginManager.invoke (project/node_modules/serverless/lib/classes/plugin-manager.js:565:20)
    at async PluginManager.run (project/node_modules/serverless/lib/classes/plugin-manager.js:604:7)
    at async Serverless.run (project/node_modules/serverless/lib/serverless.js:174:5)
    at async project/node_modules/serverless/scripts/serverless.js:771:9
```