### PR TITLE
Update schema.js to support AWS::Scheduler::Schedule

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -11,6 +11,9 @@ function extendServerlessSchema(serverless) {
   const cronSyntax = '^cron\\(\\S+ \\S+ \\S+ \\S+ \\S+ \\S+\\)$';
   const scheduleSyntax = `${rateSyntax}|${cronSyntax}`;
 
+  const METHOD_SCHEDULER = 'scheduler';
+  const METHOD_EVENT_BUS = 'eventBus';
+
   const globalConfigSchemaProperties = {
     folderName: { type: 'string' },
     cleanFolder: { type: 'boolean' },
@@ -83,6 +86,14 @@ function extendServerlessSchema(serverless) {
                     },
                     required: ['inputTemplate'],
                     additionalProperties: false,
+                  },
+                  method: {
+                    type: 'string',
+                    enum: [METHOD_EVENT_BUS, METHOD_SCHEDULER],
+                  },
+                  timezone: {
+                    type: 'string',
+                    pattern: '[\\w\\-\\/]+',
                   },
                 },
                 required: ['rate'],


### PR DESCRIPTION
Updating schema to support timezone, and method fields as per the changes made in serverless@3.39

https://github.com/serverless/serverless/blob/de62c71e30855eff688f032ff10b9ad22de13afc/lib/plugins/aws/package/compile/events/schedule.js#L81-L88