### PR TITLE
No file matches include exclude patterns fix for Windows

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ function getWarmerConfig(config, defaultOpts) {
 	/* eslint-disable no-nested-ternary */
 	return {
 		folderName,
-		pathHandler: path.join(folderName, 'index.warmUp'),
+		pathHandler: path.posix.join(folderName, 'index.warmUp'),
 		cleanFolder:
 			typeof config.cleanFolder === 'boolean' ? config.cleanFolder : defaultOpts.cleanFolder,
 		name: config.name !== undefined ? config.name : defaultOpts.name,
@@ -39,15 +39,15 @@ function getWarmerConfig(config, defaultOpts) {
 						patterns: [
 							'!**',
 							...(Array.isArray(config.package.patterns)
-								? config.package.patterns.includes(path.join(folderName, '**'))
+								? config.package.patterns.includes(path.posix.join(folderName, '**'))
 									? config.package.patterns
-									: [...config.package.patterns, path.join(folderName, '**')]
-								: [...defaultOpts.package.patterns, path.join(folderName, '**')]),
+									: [...config.package.patterns, path.posix.join(folderName, '**')]
+								: [...defaultOpts.package.patterns, path.posix.join(folderName, '**')]),
 						],
 					}
 				: {
 						...defaultOpts.package,
-						patterns: ['!**', ...defaultOpts.package.patterns, path.join(folderName, '**')],
+						patterns: ['!**', ...defaultOpts.package.patterns, path.posix.join(folderName, '**')],
 					},
 		memorySize: config.memorySize !== undefined ? config.memorySize : defaultOpts.memorySize,
 		timeout: config.timeout !== undefined ? config.timeout : defaultOpts.timeout,
@@ -152,7 +152,7 @@ function getFunctionsByWarmer(service, stage, configsByWarmer, serverlessClasses
  * */
 function getConfigsByWarmer({ service, classes }, stage) {
 	const getWarmerDefaultOpts = (warmerName) => ({
-		folderName: path.join('.warmup', warmerName),
+		folderName: path.posix.join('.warmup', warmerName),
 		cleanFolder: true,
 		memorySize: 128,
 		name: `${service.service}-${stage}-warmup-plugin-${warmerName}`,


### PR DESCRIPTION
There is defect in serverless-warmup-plugin which fails lambda warmup deployment under Windows operating system.

✖ ServerlessError2: No file matches include / exclude patterns
at file:///C:/Users/youruser/.serverless/releases/4.17.1/package/dist/sf-core.js:1151:36587
at async Package.packageFunction (file:///C:/Users/youruser/.serverless/releases/4.17.1/package/dist/sf-core.js:1151:33709)
at async file:///C:/Users/youruser/.serverless/releases/4.17.1/package/dist/sf-core.js:1151:31452
at async Promise.all (index 9)
at async Package.packageService (file:///C:/Users/youruser/.serverless/releases/4.17.1/package/dist/sf-core.js:1151:32248)
at async PluginManager.runHooks (file:///C:/Users/youruser/.serverless/releases/4.17.1/package/dist/sf-core.js:1377:9870)
at async PluginManager.invoke (file:///C:/Users/youruser/.serverless/releases/4.17.1/package/dist/sf-core.js:1377:10639)
at async PluginManager.spawn (file:///C:/Users/youruser/.serverless/releases/4.17.1/package/dist/sf-core.js:1377:11000)
at async before:deploy:deploy (file:///C:/Users/youruser/.serverless/releases/4.17.1/package/dist/sf-core.js:1151:38794)
at async PluginManager.runHooks (file:///C:/Users/youruser/.serverless/releases/4.17.1/package/dist/sf-core.js:1377:9870)

The fix is to replace path.join with path.posix.join